### PR TITLE
Resolve React key-spread warnings and update deprecated MUI v7 props

### DIFF
--- a/examples/custom-components/index.js
+++ b/examples/custom-components/index.js
@@ -21,8 +21,8 @@ const CustomTooltip = (props) => {
   return (
     <MuiTooltip
       title={props.title}
-      TransitionComponent={Fade}
-      TransitionProps={{ timeout: 250 }}
+      slots={{ transition: Fade }}
+      slotProps={{ transition: { timeout: 250 } }}
       leaveDelay={250}>{props.children}</MuiTooltip>
   );
 };

--- a/examples/custom-components/index.js
+++ b/examples/custom-components/index.js
@@ -9,19 +9,18 @@ import TableViewCol from './TableViewCol';
 const CustomChip = (props) => {
   const { label, onDelete, columnNames, className, index } = props;
   return (<Chip
-      className={className}
-      variant="outlined"
-      color={columnNames[index].name === 'Company' ? 'secondary' : 'primary'}
-      label={label}
-      onDelete={onDelete}
+    className={className}
+    variant="outlined"
+    color={columnNames[index].name === 'Company' ? 'secondary' : 'primary'}
+    label={label}
+    onDelete={onDelete}
   />);
 };
 
 const CustomTooltip = (props) => {
   return (
-    <MuiTooltip 
-      title={props.title} 
-      interactive={true} 
+    <MuiTooltip
+      title={props.title}
       TransitionComponent={Fade}
       TransitionProps={{ timeout: 250 }}
       leaveDelay={250}>{props.children}</MuiTooltip>
@@ -72,31 +71,31 @@ class Example extends React.Component {
               return false;
             },
             display: (filterList, onChange, index, column) => (
-                <Select
-                    onChange={event => {
-                      filterList[index][0] = event.target.value;
-                      onChange(filterList[index], index, column);
-                    }}
-                    value={filterList[index]}
-                >
-                  <MenuItem value="Test Corp">{'Test Corp'}</MenuItem>
-                  <MenuItem value="Other Corp">{'Other Corp'}</MenuItem>
-                </Select>
+              <Select
+                onChange={event => {
+                  filterList[index][0] = event.target.value;
+                  onChange(filterList[index], index, column);
+                }}
+                value={filterList[index]}
+              >
+                <MenuItem value="Test Corp">{'Test Corp'}</MenuItem>
+                <MenuItem value="Other Corp">{'Other Corp'}</MenuItem>
+              </Select>
             )
           },
         },
       },
       { name: 'City', label: 'City Label', options: { filterList: ['Dallas'] } },
       { name: 'State' },
-      { 
-        name: 'Empty', 
-        options: { 
-          empty: true, 
-          filterType: 'checkbox', 
+      {
+        name: 'Empty',
+        options: {
+          empty: true,
+          filterType: 'checkbox',
           filterOptions: {
             renderValue: (val) => (val ? val : '(Empty)')
           }
-        } 
+        }
       },
     ];
     const data = [
@@ -116,16 +115,16 @@ class Example extends React.Component {
 
     return (
       <MUIDataTable
-          title={"ACME Employee list"}
-          data={data}
-          columns={columns}
-          options={options}
-          components={{
-            TableFilterList: CustomFilterList,
-            Tooltip: CustomTooltip,
-            Checkbox: CustomCheckbox,
-            TableViewCol: TableViewCol
-          }}
+        title={"ACME Employee list"}
+        data={data}
+        columns={columns}
+        options={options}
+        components={{
+          TableFilterList: CustomFilterList,
+          Tooltip: CustomTooltip,
+          Checkbox: CustomCheckbox,
+          TableViewCol: TableViewCol
+        }}
       />
     );
 

--- a/examples/customize-footer/CustomFooter.js
+++ b/examples/customize-footer/CustomFooter.js
@@ -44,8 +44,8 @@ class CustomFooter extends React.Component {
                 'aria-label': textLabels.next,
               }}
               rowsPerPageOptions={[10,20,100]}
-              onChangePage={this.handlePageChange}
-              onChangeRowsPerPage={this.handleRowChange}
+              onPageChange={this.handlePageChange}
+              onRowsPerPageChange={this.handleRowChange}
             />
           </TableCell>
         </TableRow>

--- a/examples/customize-footer/CustomFooter.js
+++ b/examples/customize-footer/CustomFooter.js
@@ -37,11 +37,15 @@ class CustomFooter extends React.Component {
               page={page}
               labelRowsPerPage={textLabels.rowsPerPage}
               labelDisplayedRows={({ from, to, count }) => `${from}-${to} ${textLabels.displayRows} ${count}`}
-              backIconButtonProps={{
-                'aria-label': textLabels.previous,
-              }}
-              nextIconButtonProps={{
-                'aria-label': textLabels.next,
+              slotProps={{
+                actions: {
+                  previousButton: {
+                    'aria-label': textLabels.previous,
+                  },
+                  nextButton: {
+                    'aria-label': textLabels.next,
+                  }
+                }
               }}
               rowsPerPageOptions={[10,20,100]}
               onPageChange={this.handlePageChange}

--- a/examples/customize-styling/index.js
+++ b/examples/customize-styling/index.js
@@ -192,7 +192,7 @@ class Example extends React.Component {
       },
       setTableProps: () => {
         return {
-          padding: this.state.denseTable ? 'none' : 'default',
+          padding: this.state.denseTable ? 'none' : 'normal',
 
           // material ui v4 only
           size: this.state.denseTable ? 'small' : 'medium',

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -45,7 +45,6 @@ const Popover = ({ className, trigger, refExit, hide, content, ...providedProps 
   };
 
   const triggerProps = {
-    key: 'content',
     onClick: (event) => {
       if (trigger.props.onClick) trigger.props.onClick();
       handleClick(event);
@@ -54,7 +53,9 @@ const Popover = ({ className, trigger, refExit, hide, content, ...providedProps 
 
   return (
     <>
-      <span {...triggerProps}>{trigger}</span>
+      <span key="content" {...triggerProps}>
+        {trigger}
+      </span>
       <MuiPopover
         elevation={2}
         open={isOpen}


### PR DESCRIPTION
## Description
This PR addresses several Console warnings by modernizing deprecated prop usage across core components and examples, ensuring full compatibility with modern React environments and `@mui/material` v7.

### Changes
* **React Compatibility:** Refactored `<Popover>` to pass `key` explicitly instead of via spread object, resolving the compiler warnings introduced by modern JSX transforms.
* **MUI v7 `slotProps` Migration:** Migrated deprecated `TransitionComponent`, `TransitionProps`, `nextIconButtonProps`, and `backIconButtonProps` usage to the unified MUI v7 `slots` and `slotProps` architecture.
* **MUI v7 Prop Updates:** Replaced deprecated `padding="default"` with `"normal"` and replaced deprecated pagination handlers (`onChangePage` → `onPageChange`).
* **DOM Attribute Cleanup:** Removed the invalid `interactive={true}` boolean prop from `examples/custom-components` `<Tooltip>` to prevent it from leaking into the HTML DOM.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
