### PR TITLE
ci: tolerate already-bumped version in publish workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -52,7 +52,11 @@ jobs:
         run: |
           set -e
           OLD_VERSION=$(node -e "console.log(require('./package.json').version)")
-          npm version "${RELEASE_VERSION}" --no-git-tag-version
+          # --allow-same-version lets the workflow run cleanly when the
+          # PR that introduced this release already bumped package.json
+          # to the target version (a normal pattern when the version
+          # change is part of the reviewable diff).
+          npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
           NEW_VERSION=$(node -e "console.log(require('./package.json').version)")
           echo "Updated Package Version" >> $GITHUB_STEP_SUMMARY
           echo "info Old Version: ${OLD_VERSION}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Pass --allow-same-version to npm version so the publish workflow runs cleanly when the PR that created the release already bumped package.json. Surfaced when the v7.0.0 release auto-publish failed because PR #53 had pre-bumped to 7.0.0.