### PR TITLE
test(deps): make suite pass on React 19 / MUI 9 / chai 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,9 +2074,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
-      "integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2549,6 +2549,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2566,6 +2569,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2583,6 +2589,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2600,6 +2609,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2617,6 +2629,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2634,6 +2649,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2651,6 +2669,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2668,6 +2689,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2685,6 +2709,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2708,6 +2735,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2731,6 +2761,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2754,6 +2787,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2777,6 +2813,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2800,6 +2839,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2823,6 +2865,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2846,6 +2891,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3645,13 +3693,6 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@mui/private-theming": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.0.tgz",
@@ -3805,13 +3846,6 @@
         }
       }
     },
-    "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@next/env": {
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
@@ -3861,6 +3895,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3878,6 +3915,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3895,6 +3935,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3912,6 +3955,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4403,6 +4449,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4417,6 +4466,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4431,6 +4483,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4445,6 +4500,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4459,6 +4517,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4473,6 +4534,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4487,6 +4551,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4501,6 +4568,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4515,6 +4585,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4529,6 +4602,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4543,6 +4619,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4557,6 +4636,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4571,6 +4653,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5801,9 +5886,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
-      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8900,12 +8985,6 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -9368,9 +9447,9 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10196,6 +10275,21 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/js-tokens": {
@@ -12345,12 +12439,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12636,10 +12724,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
     "node_modules/react-router": {
@@ -14495,21 +14582,6 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -14602,22 +14674,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
-      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.29"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
-      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2549,9 +2549,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2569,9 +2566,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2589,9 +2583,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2609,9 +2600,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2629,9 +2617,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2649,9 +2634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2669,9 +2651,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2689,9 +2668,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2709,9 +2685,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2735,9 +2708,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2761,9 +2731,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2787,9 +2754,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2813,9 +2777,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2839,9 +2800,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2865,9 +2823,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2891,9 +2846,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3895,9 +3847,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3915,9 +3864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3935,9 +3881,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3955,9 +3898,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4449,9 +4389,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4466,9 +4403,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4483,9 +4417,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4500,9 +4431,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4517,9 +4445,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4534,9 +4459,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4551,9 +4473,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4568,9 +4487,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4585,9 +4501,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4602,9 +4515,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4619,9 +4529,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4636,9 +4543,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4653,9 +4557,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "test-exclude": "^8.0.0",
     "diff": "^8.0.4",
     "minimatch": ">=3.1.4",
-    "serialize-javascript": "^7.0.4"
+    "serialize-javascript": "^7.0.4",
+    "react-is": "^19.2.5"
   },
   "side-effects": false,
   "nyc": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,9 +2,24 @@ import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 import uglify from '@lopatnov/rollup-plugin-uglify';
+import { createRequire } from 'module';
+
+const pkg = createRequire(import.meta.url)('./package.json');
+
+// Treat anything declared as a dependency or peerDependency as external —
+// including subpath imports like `@babel/runtime-corejs3/helpers/extends` —
+// since they belong to the consumer's resolution graph, not our bundle.
+const externals = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {}),
+];
+const externalRegex = new RegExp(
+  '^(' + externals.map((d) => d.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')).join('|') + ')(/|$)',
+);
 
 export default {
   input: 'src/index.js',
+  external: (id) => externalRegex.test(id),
   plugins: [
     replace({
       'process.env.NODE_ENV': JSON.stringify('production'),

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -75,25 +75,29 @@ function TablePagination(props) {
               page={getPageValue(count, rowsPerPage, page)}
               labelRowsPerPage={textLabels.rowsPerPage}
               labelDisplayedRows={({ from, to, count }) => `${from}-${to} ${textLabels.displayRows} ${count}`}
-              backIconButtonProps={{
-                id: 'pagination-back',
-                'data-testid': 'pagination-back',
-                'aria-label': textLabels.previous,
-                title: textLabels.previous || '',
-              }}
-              nextIconButtonProps={{
-                id: 'pagination-next',
-                'data-testid': 'pagination-next',
-                'aria-label': textLabels.next,
-                title: textLabels.next || '',
-              }}
-              SelectProps={{
-                id: 'pagination-input',
-                SelectDisplayProps: { id: 'pagination-rows', 'data-testid': 'pagination-rows' },
-                MenuProps: {
-                  id: 'pagination-menu',
-                  'data-testid': 'pagination-menu',
-                  MenuListProps: { id: 'pagination-menu-list', 'data-testid': 'pagination-menu-list' },
+              slotProps={{
+                actions: {
+                  previousButton: {
+                    id: 'pagination-back',
+                    'data-testid': 'pagination-back',
+                    'aria-label': textLabels.previous,
+                    title: textLabels.previous || '',
+                  },
+                  nextButton: {
+                    id: 'pagination-next',
+                    'data-testid': 'pagination-next',
+                    'aria-label': textLabels.next,
+                    title: textLabels.next || '',
+                  },
+                },
+                select: {
+                  id: 'pagination-input',
+                  SelectDisplayProps: { id: 'pagination-rows', 'data-testid': 'pagination-rows' },
+                  MenuProps: {
+                    id: 'pagination-menu',
+                    'data-testid': 'pagination-menu',
+                    MenuListProps: { id: 'pagination-menu-list', 'data-testid': 'pagination-menu-list' },
+                  },
                 },
               }}
               rowsPerPageOptions={options.rowsPerPageOptions}

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -11,7 +11,7 @@ import Popover from './Popover';
 import TableFilter from './TableFilter';
 import TableViewCol from './TableViewCol';
 import TableSearch from './TableSearch';
-import ReactToPrint, { PrintContextConsumer } from 'react-to-print';
+import { useReactToPrint } from 'react-to-print';
 import find from 'lodash.find';
 import { withStyles } from 'tss-react/mui';
 import { createCSVDownload, downloadCSV } from '../utils';
@@ -102,6 +102,27 @@ export const defaultToolbarStyles = (theme) => ({
 });
 
 const RESPONSIVE_FULL_WIDTH_NAME = 'scrollFullHeightFullWidth';
+
+const PrintButton = ({ getContent, classes, IconComponent, options, print, Tooltip }) => {
+  const contentRef = React.useRef(null);
+  const handlePrint = useReactToPrint({ contentRef });
+  const onClick = () => {
+    contentRef.current = getContent();
+    handlePrint();
+  };
+  return (
+    <Tooltip title={print}>
+      <IconButton
+        data-testid={print + '-iconButton'}
+        aria-label={print}
+        disabled={options.print === 'disabled'}
+        onClick={onClick}
+        classes={{ root: classes.icon }}>
+        <IconComponent />
+      </IconButton>
+    </Tooltip>
+  );
+};
 
 class TableToolbar extends React.Component {
   state = {
@@ -379,24 +400,14 @@ class TableToolbar extends React.Component {
           )}
           {!(options.print === false || options.print === 'false') && (
             <span>
-              <ReactToPrint content={() => this.props.tableRef()}>
-                <PrintContextConsumer>
-                  {({ handlePrint }) => (
-                    <span>
-                      <Tooltip title={print}>
-                        <IconButton
-                          data-testid={print + '-iconButton'}
-                          aria-label={print}
-                          disabled={options.print === 'disabled'}
-                          onClick={handlePrint}
-                          classes={{ root: classes.icon }}>
-                          <PrintIconComponent />
-                        </IconButton>
-                      </Tooltip>
-                    </span>
-                  )}
-                </PrintContextConsumer>
-              </ReactToPrint>
+              <PrintButton
+                getContent={() => this.props.tableRef()}
+                classes={classes}
+                IconComponent={PrintIconComponent}
+                options={options}
+                print={print}
+                Tooltip={Tooltip}
+              />
             </span>
           )}
           {!(options.viewColumns === false || options.viewColumns === 'false') && (

--- a/test/setup-mocha-env.js
+++ b/test/setup-mocha-env.js
@@ -1,12 +1,5 @@
-import Enzyme from 'enzyme';
-import React from 'react';
-import AdapterPkg from '@cfaester/enzyme-adapter-react-18';
-
-const Adapter = AdapterPkg.default || AdapterPkg;
-
-/* required when running >= 16.0 */
-Enzyme.configure({ adapter: new Adapter() });
-
+// jsdom must be set up before react / enzyme / adapter are loaded so that
+// any module reading `globalThis.window` at import time sees the DOM.
 function setupDom() {
   const { JSDOM } = require('jsdom');
   const Node = require('jsdom/lib/jsdom/living/node-document-position');
@@ -63,8 +56,9 @@ function setupDom() {
   global.getComputedStyle = global.window.getComputedStyle;
   global.HTMLInputElement = global.window.HTMLInputElement;
   global.Element = global.window.Element;
-  global.Event = global.window.Event;
-  global.dispatchEvent = global.window.dispatchEvent;
+  // Intentionally not overriding global.Event / global.dispatchEvent: chai 6
+  // dispatches its own PluginEvent (extending Event) to a native EventTarget,
+  // and replacing Event with jsdom's class makes Node reject the dispatch.
   global.window.getComputedStyle = () => ({});
 
   Object.defineProperty(global.window.URL, 'createObjectURL', { value: () => {} });
@@ -74,4 +68,200 @@ function setupDom() {
 }
 
 setupDom();
+
+// React 19 removed the legacy internals object that enzyme's React 18 adapter
+// (via react-shallow-renderer) writes its hook dispatcher into, and React 19's
+// hooks read from a module-private `ReactSharedInternals` we can't reach.
+// Reconstruct the React 18 surface and route React.use* calls through whatever
+// dispatcher the shallow renderer parks on it during a render pass.
+const React = require('react');
+if (!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED) {
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+    ReactCurrentDispatcher: { current: null },
+    ReactCurrentBatchConfig: { transition: null },
+    ReactDebugCurrentFrame: { getCurrentStack: () => '' },
+    ReactCurrentOwner: { current: null },
+  };
+  // React 19 retains a `_owner` reference (to the parent FiberNode) on every
+  // element created during render and freezes the element so the back-reference
+  // can't be cleared after the fact. Tests that JSON.stringify state containing
+  // React elements (e.g. `customBodyRender` output stashed in displayData) trip
+  // on the resulting fiber→DOM→fiber cycle. Skip Object.freeze for React
+  // elements so we can null `_owner` at element creation time, then patch both
+  // JSX entry points babel may emit.
+  const REACT_ELEMENT_SYMBOLS = new Set([
+    Symbol.for('react.element'),
+    Symbol.for('react.transitional.element'),
+  ]);
+  const origFreeze = Object.freeze;
+  Object.freeze = function patchedFreeze(obj) {
+    if (obj && typeof obj === 'object' && REACT_ELEMENT_SYMBOLS.has(obj.$$typeof)) {
+      return obj;
+    }
+    return origFreeze.apply(Object, arguments);
+  };
+  const stripOwner = (el) => {
+    if (el && typeof el === 'object' && REACT_ELEMENT_SYMBOLS.has(el.$$typeof)) {
+      try { el._owner = null; } catch (_) { /* still frozen elsewhere */ }
+    }
+    return el;
+  };
+  const origCreateElement = React.createElement;
+  React.createElement = function patchedCreateElement() {
+    return stripOwner(origCreateElement.apply(this, arguments));
+  };
+  for (const mod of ['react/jsx-runtime', 'react/jsx-dev-runtime']) {
+    try {
+      const rt = require(mod);
+      for (const fn of ['jsx', 'jsxs', 'jsxDEV']) {
+        if (typeof rt[fn] === 'function') {
+          const orig = rt[fn];
+          rt[fn] = function patchedJsx() {
+            return stripOwner(orig.apply(this, arguments));
+          };
+        }
+      }
+    } catch (_) { /* runtime variant not present */ }
+  }
+
+  const internals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  const hooks = [
+    'useState',
+    'useReducer',
+    'useContext',
+    'useRef',
+    'useEffect',
+    'useLayoutEffect',
+    'useInsertionEffect',
+    'useCallback',
+    'useMemo',
+    'useImperativeHandle',
+    'useDebugValue',
+    'useTransition',
+    'useDeferredValue',
+    'useId',
+    'useSyncExternalStore',
+  ];
+  for (const name of hooks) {
+    const native = React[name];
+    React[name] = function () {
+      const dispatcher = internals.ReactCurrentDispatcher.current;
+      if (dispatcher && typeof dispatcher[name] === 'function') {
+        return dispatcher[name].apply(dispatcher, arguments);
+      }
+      return native.apply(React, arguments);
+    };
+  }
+}
+
+// React 19 stripped `Simulate` from `react-dom/test-utils`, but the enzyme
+// React 18 adapter calls `Simulate[event](hostNode, mock)`. Reconstruct it by
+// dispatching a native event on the host node — React 19 attaches its event
+// listeners on the root container, so a bubbled native event hits them.
+const testUtils = require('react-dom/test-utils');
+if (!testUtils.Simulate) {
+  const eventCtor = (win, type) => {
+    if (/^(click|mouse|drag|drop|wheel|context|pointer|touch)/.test(type) && win.MouseEvent) return win.MouseEvent;
+    if (/^key/.test(type) && win.KeyboardEvent) return win.KeyboardEvent;
+    if (/^(focus|blur)/.test(type) && win.FocusEvent) return win.FocusEvent;
+    return win.Event;
+  };
+  const eventNames = [
+    'click', 'doubleClick', 'mouseDown', 'mouseUp', 'mouseMove', 'mouseEnter', 'mouseLeave',
+    'mouseOver', 'mouseOut', 'change', 'input', 'keyDown', 'keyUp', 'keyPress',
+    'focus', 'blur', 'submit', 'select', 'paste', 'copy', 'cut', 'drag', 'drop',
+    'dragStart', 'dragEnd', 'dragEnter', 'dragLeave', 'dragOver', 'wheel',
+    'touchStart', 'touchEnd', 'touchMove', 'touchCancel', 'pointerDown', 'pointerUp',
+    'pointerMove', 'pointerEnter', 'pointerLeave', 'pointerOver', 'pointerOut',
+    'contextMenu', 'scroll',
+  ];
+  const setInputValue = (node, value) => {
+    // React 19 attaches a value tracker that suppresses onChange when the new
+    // value matches the last tracked one. Reset the tracker so an empty-to-
+    // empty assignment (a common test pattern) still produces a synthetic
+    // onChange.
+    if (node._valueTracker && typeof node._valueTracker.setValue === 'function') {
+      node._valueTracker.setValue(String(value) + '__simulated__');
+    }
+    const proto = Object.getPrototypeOf(node);
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+    if (desc && desc.set) desc.set.call(node, value);
+    else node.value = value;
+  };
+  // `target` is a getter on native Event; skip it (and any other mock keys we
+  // can't reassign) when copying the user's mock onto the dispatched event.
+  const safeAssign = (event, mock) => {
+    if (!mock) return;
+    for (const key of Object.keys(mock)) {
+      try {
+        event[key] = mock[key];
+      } catch (e) { /* ignore non-writable getters */ }
+    }
+  };
+  testUtils.Simulate = {};
+  for (const name of eventNames) {
+    testUtils.Simulate[name] = (node, mock = {}) => {
+      if (!node) return;
+      const win = node.ownerDocument ? node.ownerDocument.defaultView : global.window;
+      const type = name.replace(/[A-Z]/g, (c) => c.toLowerCase()).toLowerCase();
+      // React listens for native `input` (not `change`) on text inputs/textareas;
+      // checkboxes/radios fire `change` from `click`. Mirror the host's behavior
+      // so `simulate('change', { target: { value } })` actually updates state.
+      if (type === 'change' && mock && mock.target) {
+        const isCheckable = node.tagName === 'INPUT' && (node.type === 'checkbox' || node.type === 'radio');
+        if (isCheckable) {
+          if ('checked' in mock.target) node.checked = mock.target.checked;
+          // React's checkbox onChange handler is wired to native `click`.
+          const clickEvent = new (win.MouseEvent || win.Event)('click', { bubbles: true, cancelable: true });
+          node.dispatchEvent(clickEvent);
+          return;
+        }
+        if ('value' in mock.target && (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA' || node.tagName === 'SELECT')) {
+          setInputValue(node, mock.target.value);
+          const inputEvent = new win.Event('input', { bubbles: true, cancelable: true });
+          node.dispatchEvent(inputEvent);
+        }
+      }
+      const Ctor = eventCtor(win, type);
+      // Tests pass modifier keys via either `mock.shiftKey` or `mock.nativeEvent.shiftKey`;
+      // both end up reflected on the native event we dispatch.
+      const init = { bubbles: true, cancelable: true, ...(mock.nativeEvent || {}), ...mock };
+      delete init.target;
+      delete init.nativeEvent;
+      const event = new Ctor(type, init);
+      safeAssign(event, mock);
+      node.dispatchEvent(event);
+    };
+  }
+}
+
+// React 19 dropped `findDOMNode` from react-dom; the enzyme React 18 adapter
+// still calls it to resolve host nodes for class component instances.
+const ReactDOM = require('react-dom');
+if (typeof ReactDOM.findDOMNode !== 'function') {
+  ReactDOM.findDOMNode = (instance) => {
+    if (!instance) return null;
+    if (instance.nodeType) return instance;
+    const fiber = instance._reactInternals || instance._reactInternalFiber;
+    if (!fiber) return null;
+    const queue = [fiber];
+    while (queue.length) {
+      const f = queue.shift();
+      if (f.stateNode && f.stateNode.nodeType) return f.stateNode;
+      let child = f.child;
+      while (child) {
+        queue.push(child);
+        child = child.sibling;
+      }
+    }
+    return null;
+  };
+}
+
+const Enzyme = require('enzyme');
+const AdapterPkg = require('@cfaester/enzyme-adapter-react-18');
+const Adapter = AdapterPkg.default || AdapterPkg;
+
+Enzyme.configure({ adapter: new Adapter() });
+
 console.error = function () {};

--- a/test/setup-mocha-env.js
+++ b/test/setup-mocha-env.js
@@ -161,7 +161,7 @@ if (!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED) {
 const testUtils = require('react-dom/test-utils');
 if (!testUtils.Simulate) {
   const eventCtor = (win, type) => {
-    if (/^(click|mouse|drag|drop|wheel|context|pointer|touch)/.test(type) && win.MouseEvent) return win.MouseEvent;
+    if (/^(click|dbl|mouse|drag|drop|wheel|context|pointer|touch)/.test(type) && win.MouseEvent) return win.MouseEvent;
     if (/^key/.test(type) && win.KeyboardEvent) return win.KeyboardEvent;
     if (/^(focus|blur)/.test(type) && win.FocusEvent) return win.FocusEvent;
     return win.Event;
@@ -198,12 +198,15 @@ if (!testUtils.Simulate) {
       } catch (e) { /* ignore non-writable getters */ }
     }
   };
+  // Most React event names lowercase cleanly to their native counterpart, but a
+  // few don't — e.g. `doubleClick` is `dblclick`, not `doubleclick`.
+  const eventNameAliases = { doubleClick: 'dblclick' };
   testUtils.Simulate = {};
   for (const name of eventNames) {
     testUtils.Simulate[name] = (node, mock = {}) => {
       if (!node) return;
       const win = node.ownerDocument ? node.ownerDocument.defaultView : global.window;
-      const type = name.replace(/[A-Z]/g, (c) => c.toLowerCase()).toLowerCase();
+      const type = eventNameAliases[name] || name.toLowerCase();
       // React listens for native `input` (not `change`) on text inputs/textareas;
       // checkboxes/radios fire `change` from `click`. Mirror the host's behavior
       // so `simulate('change', { target: { value } })` actually updates state.
@@ -245,8 +248,8 @@ if (typeof ReactDOM.findDOMNode !== 'function') {
     const fiber = instance._reactInternals || instance._reactInternalFiber;
     if (!fiber) return null;
     const queue = [fiber];
-    while (queue.length) {
-      const f = queue.shift();
+    for (let i = 0; i < queue.length; i++) {
+      const f = queue[i];
       if (f.stateNode && f.stateNode.nodeType) return f.stateNode;
       let child = f.child;
       while (child) {

--- a/test/setup-mocha-env.js
+++ b/test/setup-mocha-env.js
@@ -89,10 +89,7 @@ if (!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED) {
   // on the resulting fiber→DOM→fiber cycle. Skip Object.freeze for React
   // elements so we can null `_owner` at element creation time, then patch both
   // JSX entry points babel may emit.
-  const REACT_ELEMENT_SYMBOLS = new Set([
-    Symbol.for('react.element'),
-    Symbol.for('react.transitional.element'),
-  ]);
+  const REACT_ELEMENT_SYMBOLS = new Set([Symbol.for('react.element'), Symbol.for('react.transitional.element')]);
   const origFreeze = Object.freeze;
   Object.freeze = function patchedFreeze(obj) {
     if (obj && typeof obj === 'object' && REACT_ELEMENT_SYMBOLS.has(obj.$$typeof)) {
@@ -102,7 +99,11 @@ if (!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED) {
   };
   const stripOwner = (el) => {
     if (el && typeof el === 'object' && REACT_ELEMENT_SYMBOLS.has(el.$$typeof)) {
-      try { el._owner = null; } catch (_) { /* still frozen elsewhere */ }
+      try {
+        el._owner = null;
+      } catch (_) {
+        /* still frozen elsewhere */
+      }
     }
     return el;
   };
@@ -121,7 +122,9 @@ if (!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED) {
           };
         }
       }
-    } catch (_) { /* runtime variant not present */ }
+    } catch (_) {
+      /* runtime variant not present */
+    }
   }
 
   const internals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
@@ -167,13 +170,48 @@ if (!testUtils.Simulate) {
     return win.Event;
   };
   const eventNames = [
-    'click', 'doubleClick', 'mouseDown', 'mouseUp', 'mouseMove', 'mouseEnter', 'mouseLeave',
-    'mouseOver', 'mouseOut', 'change', 'input', 'keyDown', 'keyUp', 'keyPress',
-    'focus', 'blur', 'submit', 'select', 'paste', 'copy', 'cut', 'drag', 'drop',
-    'dragStart', 'dragEnd', 'dragEnter', 'dragLeave', 'dragOver', 'wheel',
-    'touchStart', 'touchEnd', 'touchMove', 'touchCancel', 'pointerDown', 'pointerUp',
-    'pointerMove', 'pointerEnter', 'pointerLeave', 'pointerOver', 'pointerOut',
-    'contextMenu', 'scroll',
+    'click',
+    'doubleClick',
+    'mouseDown',
+    'mouseUp',
+    'mouseMove',
+    'mouseEnter',
+    'mouseLeave',
+    'mouseOver',
+    'mouseOut',
+    'change',
+    'input',
+    'keyDown',
+    'keyUp',
+    'keyPress',
+    'focus',
+    'blur',
+    'submit',
+    'select',
+    'paste',
+    'copy',
+    'cut',
+    'drag',
+    'drop',
+    'dragStart',
+    'dragEnd',
+    'dragEnter',
+    'dragLeave',
+    'dragOver',
+    'wheel',
+    'touchStart',
+    'touchEnd',
+    'touchMove',
+    'touchCancel',
+    'pointerDown',
+    'pointerUp',
+    'pointerMove',
+    'pointerEnter',
+    'pointerLeave',
+    'pointerOver',
+    'pointerOut',
+    'contextMenu',
+    'scroll',
   ];
   const setInputValue = (node, value) => {
     // React 19 attaches a value tracker that suppresses onChange when the new
@@ -195,7 +233,9 @@ if (!testUtils.Simulate) {
     for (const key of Object.keys(mock)) {
       try {
         event[key] = mock[key];
-      } catch (e) { /* ignore non-writable getters */ }
+      } catch (e) {
+        /* ignore non-writable getters */
+      }
     }
   };
   // Most React event names lowercase cleanly to their native counterpart, but a
@@ -219,7 +259,10 @@ if (!testUtils.Simulate) {
           node.dispatchEvent(clickEvent);
           return;
         }
-        if ('value' in mock.target && (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA' || node.tagName === 'SELECT')) {
+        if (
+          'value' in mock.target &&
+          (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA' || node.tagName === 'SELECT')
+        ) {
           setInputValue(node, mock.target.value);
           const inputEvent = new win.Event('input', { bubbles: true, cancelable: true });
           node.dispatchEvent(inputEvent);


### PR DESCRIPTION
## Summary
- Restore the React 17/18-shaped test surface that enzyme + react-shallow-renderer + the cfaester adapter still expect, layered on top of the upgraded React 19 runtime — `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` stub, hook-call → shallow-renderer dispatcher routing, fiber-walking `findDOMNode`, native-event-based `Simulate` (with input value-tracker reset + checkbox-via-click), and an `Object.freeze` skip for React elements so we can null `_owner` at creation.
- Migrate two components whose APIs broke in the dep bump: `TablePagination` to MUI v9's `slotProps.actions.{previousButton,nextButton}` / `slotProps.select`, and `TableToolbar` from the dropped `<ReactToPrint>` / `<PrintContextConsumer>` pair to a `useReactToPrint` hook wrapper.
- Override `react-is` to ^19.2.5 so the adapter's element check recognizes React 19's `react.transitional.element` symbol, and externalize runtime deps in `rollup.config.js` so peerDeps and `@babel/runtime-corejs3/*` subpaths stop tripping rollup's "Unresolved dependencies" warning.

Result: `npm test` → 234 passing, 0 failing. `rollup -c` → no unresolved-dependency warnings.

## Test plan
- [x] `npm test` — full mocha suite passes (234 tests)
- [x] `npx rollup -c` — clean build, no "Unresolved dependencies" warning
- [ ] CI green on this branch